### PR TITLE
fix(images): add sizes to fill image, unoptimized to animated gif

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -79,6 +79,7 @@ function AboutPage() {
                   alt="security researcher"
                   width="120"
                   height="120"
+                  unoptimized
                   className="rounded-md"
                 />
               </TooltipContent>

--- a/src/components/article/article.tsx
+++ b/src/components/article/article.tsx
@@ -33,6 +33,7 @@ function Article({ guid, title, categories, thumbnail, slug }: ArticleProps) {
             )}
             src={thumbnail}
             fill
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 340px"
             alt="Article's cover image"
           />
         </div>


### PR DESCRIPTION
Stacked on #39 — merges into `feature/blog`.

## Summary
Fixes the dev-console `next/image` warnings seen when running the blog branch:

- `src/components/article/article.tsx` — the only `<Image fill>` missing `sizes`. Added `sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 340px"`, derived from the home `ArticleGrid` layout: `auto-fill minmax(275px,1fr)` inside a 1100px `MaxWidthWrapper` yields 1 column below ~600px, 2 columns to ~920px, and a max of 3 columns whose cells top out at ~329px — so a fixed 340px upper bound instead of an ever-growing `33vw`.
- `src/app/about/page.tsx` — added `unoptimized` to the animated Tenor GIF (animated images bypass the optimizer anyway; this silences the warning).

Audited every other `fill`/`<Image>` usage: the MDX `img` override already had a correct `sizes` for the 768px prose container, and `/blog` renders no images — nothing else needed changing. No visual/layout changes.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 32 passed
- [x] `pnpm build` — all 18 pages generated
- [x] `pnpm dev` + requests to `/`, `/blog`, `/blog/hello-world`, `/about` — no image warnings in the dev log

🤖 Generated with [Claude Code](https://claude.com/claude-code)