### PR TITLE
chore(blog): mark hello-world sample as draft

### DIFF
--- a/content/blog/hello-world.mdx
+++ b/content/blog/hello-world.mdx
@@ -7,6 +7,7 @@ tags:
   - nextjs
   - blog
 coverImage: /images/hello-world-cover.svg
+draft: true
 ---
 
 Welcome to the first locally-authored post on this site. It lives as a plain


### PR DESCRIPTION
## Summary
Hides the `hello-world` sample post from the public site (kept in the repo as a dev-only reference — drafts still render in `pnpm dev`). One-line frontmatter change: `draft: true`.

Audited all public surfaces in a production build — `/blog` index, `generateStaticParams`, the `[slug]` runtime lookup (direct URL hit 404s, verified the code path), home `ArticleGrid`, and sitemap all go through the draft-filtered post helpers; nothing leaks.

## Test plan
- [x] `pnpm lint` / `pnpm test` (32/32) / `pnpm build` all pass
- [x] `.next/prerender-manifest.json` — no hello-world, only the 10 Medium slugs
- [x] Prerendered sitemap has zero hello-world references

🤖 Generated with [Claude Code](https://claude.com/claude-code)